### PR TITLE
update deprecated/removed modules and functions

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,7 +11,8 @@ pages = [
 ]
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = ">= 0.45.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.41.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1B2F80CB1B66B027E3198A2FF71EF3F2F31DF89ED97AD606F25FD387A4C3C1EF" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.52.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "50703862DF26453B277688FFCDBE9DD4AC45B3BD9742C0B370DB62BC1629A07D" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.45.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/atto/text.gleam
+++ b/src/atto/text.gleam
@@ -1,7 +1,7 @@
 //// Functions for parsing over strings.
 
 import gleam/list
-import gleam/regex
+import gleam/regexp
 import gleam/set
 import gleam/string
 
@@ -54,12 +54,12 @@ fn get_line(s, i) {
 /// // -> Ok(123.456)
 /// ```
 pub fn match(regex: String) -> Parser(String, String, String, c, e) {
-  let r = case regex.from_string("^" <> regex) {
+  let r = case regexp.from_string("^" <> regex) {
     Ok(r) -> r
     Error(e) -> panic as e.error
   }
   fn(in: ParserInput(String, String), pos, ctx) {
-    case regex.scan(r, in.src) {
+    case regexp.scan(r, in.src) {
       [] ->
         case atto.get_token(in, pos) {
           Ok(#(t, _, pos2)) ->
@@ -77,7 +77,7 @@ pub fn match(regex: String) -> Parser(String, String, String, c, e) {
         }
       [m, ..] -> {
         let x = m.content
-        let xs = string.drop_left(in.src, string.length(m.content))
+        let xs = string.drop_start(in.src, string.length(m.content))
         let p = advance_pos_string(pos, x)
         Ok(#(x, atto.ParserInput(..in, src: xs), p, ctx))
       }

--- a/src/atto/text_util.gleam
+++ b/src/atto/text_util.gleam
@@ -205,7 +205,7 @@ pub fn char_lit() {
     match("\\\\t") |> atto.map(fn(_) { "\u{0009}" }),
     match("\\\\u\\{[0-9a-fA-F]{4}\\}")
       |> atto.map(fn(x) {
-        let assert Ok(n) = int.base_parse(string.drop_left(x, 2), 16)
+        let assert Ok(n) = int.base_parse(string.drop_start(x, 2), 16)
         let assert Ok(cp) = string.utf_codepoint(n)
         string.from_utf_codepoints([cp])
       }),


### PR DESCRIPTION
This fixes compilation errors + warnings (caused by the moving of gleam/regex to its own package and the deprecation of string.drop_left) when using atto with the current version of gleam/stdlib

great library btw!